### PR TITLE
Fl/bcloud user items with options and details

### DIFF
--- a/lib/src/braincloud_user_items.dart
+++ b/lib/src/braincloud_user_items.dart
@@ -22,11 +22,11 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - AwardUserItem
   ///
-  /// @param defId
+  /// @param defId The unique id of the item definition to award.
   ///
-  /// @param quantity
+  /// @param quantity The quantity of the item to award.
   ///
-  /// @param includeDef
+  /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> awardUserItem(
@@ -63,11 +63,11 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - DropUserItem
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
-  /// @param quantity
+  /// @param quantity The quantity of the user item to drop.
   ///
-  /// @param includeDef
+  /// @param includeDef If true and any quantity of the user item remains, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> dropUserItem(
@@ -103,9 +103,9 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - GetUserInventoryPage
   ///
-  /// @param context
+  /// @param context The json context for the page request.
   ///
-  /// @param includeDef
+  /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> getUserItemsPage(
@@ -140,11 +140,11 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - GetUserInventoryPageOffset
   ///
-  /// @param context
+  /// @param context The context string returned from the server from a previous call to SysGetCatalogItemsPage or SysGetCatalogItemsPageOffset.
   ///
-  /// @param pageOffset
+  /// @param pageOffset The positive or negative page offset to fetch. Uses the last page retrieved using the context string to determine a starting point.
   ///
-  /// @param includeDef
+  /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> getUserItemsPageOffset(
@@ -180,9 +180,9 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
-  /// @param includeDef
+  /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> getUserItem(
@@ -212,15 +212,15 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
-  /// @param profileId
+  /// @param profileId The ID of the recipient's user profile.
   ///
-  /// @param itemId
+  /// @param itemId The ID uniquely identifying the user item to be transferred.
   ///
-  /// @param version
+  /// @param version The version of the user item being transferred.
   ///
-  /// @param quantity
+  /// @param quantity The quantity of the user item to transfer.
   ///
-  /// @param immediate
+  /// @param immediate Flag set to true if item is to be immediately transferred, otherwise false to have the sender sents an event and transfers item(s) only when recipient calls receiveUserItemFrom.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> giveUserItemTo(
@@ -260,13 +260,13 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
-  /// @param defId
+  /// @param defId The unique id of the item definition to purchase.
   ///
-  /// @param quatity
+  /// @param quatity The quantity of the item to purchase.
   ///
-  /// @param shopId
+  /// @param shopId The id identifying the store the item is being purchased from (not yet supported). Use null or empty string to specify the default shop price.
   ///
-  /// @param includeDef
+  /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> purchaseUserItem(
@@ -297,18 +297,14 @@ class BrainCloudUserItems {
   }
 
   /// Retrieves and transfers the gift item from the specified player,
-  //who must have previously called giveUserItemTo.
+  /// who must have previously called giveUserItemTo.
   ///
   /// Service Name - userItems
-  /// Service Operation - GetUserItem
+  /// Service Operation - receiveUserItemFrom
   ///
-  /// @param defId
+  /// @param profileId The profile ID of the user who is giving the item.
   ///
-  /// @param quatity
-  ///
-  /// @param shopId
-  ///
-  /// @param includeDef
+  /// @param itemId The ID uniquely identifying the user item to be transferred.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> receiveUserItemFrom(
@@ -343,15 +339,15 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - SellUserItem
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
-  /// @param version
+  /// @param version The version of the user item being sold.
   ///
-  /// @param quantity
+  /// @param quantity The quantity of the user item to sell.
   ///
-  /// @param shopId
+  /// @param shopId 	The id identifying the store the item is being purchased from (not yet supported). Use null or empty string to specify the default shop price.
   ///
-  /// @param includeDef
+  /// @param includeDef 	If true and any quantity of the user item remains, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> sellUserItem(
@@ -388,11 +384,11 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - UpdateUserItemData
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
-  /// @param version
+  /// @param version The version of the user item being updated.
   ///
-  /// @param newItemData
+  /// @param newItemData New item data to replace existing user item data.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> updateUserItemData(
@@ -426,13 +422,13 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - UseUserItem
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
-  /// @param version
+  /// @param version The version of the user item being used.
   ///
-  /// @param newItemData
+  /// @param newItemData Optional item data to replace existing user item data. Specify null to leave item data unchanged. Specify empty map to clear item data.
   ///
-  /// @param includeDef
+  /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> useUserItem(
@@ -468,9 +464,9 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - PublishUserItemToBlockchain
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
-  /// @param version
+  /// @param version The version of the user item being published.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> publishUserItemToBlockchain(
@@ -525,10 +521,10 @@ class BrainCloudUserItems {
   /// Service Name - userItems
   /// Service Operation - RemoveUserItemFromBlockchain
   ///
-  /// @param itemId
+  /// @param itemId The unique id of the user item.
   ///
   ///
-  /// @param version
+  /// @param version The version of the user item being removed.
   ///
   /// returns `Future<ServerResponse>`
   Future<ServerResponse> removeUserItemFromBlockchain(
@@ -577,6 +573,7 @@ class BrainCloudUserItems {
   ///  response key 'itemsNotAwarded' - unless the adjusted quantity would be 
   ///  0, in which case the call is blocked and an error is returned.
   ///
+  /// returns `Future<ServerResponse>`
   Future<ServerResponse> awardUserItemWithOptions(
       {required String defId,
       required int quantity,
@@ -629,6 +626,8 @@ class BrainCloudUserItems {
   ///  to the allowed maximum and the quantity not awarded is reported in 
   ///  response key 'itemsNotAwarded' - unless the adjusted quantity would be 
   ///  0, in which case the call is blocked and an error is returned.
+  ///
+  ///  returns `Future<ServerResponse>`
   Future<ServerResponse> purchaseUserItemWithOptions(
       {required String defId,
       required int quantity,
@@ -667,7 +666,8 @@ class BrainCloudUserItems {
   /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// @param includePromotionDetails If true, the promotion details of the eligible promotions will be included in the response.
-  /// 
+  /// ///
+  ///  returns `Future<ServerResponse>`
   Future<ServerResponse> getItemsOnPromotion(
       {required String shopId,
       required bool includeDef,
@@ -707,7 +707,8 @@ class BrainCloudUserItems {
   /// @param includeDef If true, the associated item definition will be included in the response.
   ///
   /// @param includePromotionDetails If true, the promotion details of the eligible promotions will be included in the response.
-  /// 
+  /// ///
+  ///  returns `Future<ServerResponse>`
   Future<ServerResponse> getItemPromotionDetails(
       {required String defId,
       required String shopId,

--- a/lib/src/braincloud_user_items.dart
+++ b/lib/src/braincloud_user_items.dart
@@ -19,7 +19,7 @@ class BrainCloudUserItems {
   /// includes associated itemDef with language fields limited
   /// to the current or default language.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - AwardUserItem
   ///
   /// @param defId
@@ -60,7 +60,7 @@ class BrainCloudUserItems {
   ///with the associated itemDef (with language fields limited to the
   ///current or default language).
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - DropUserItem
   ///
   /// @param itemId
@@ -100,7 +100,7 @@ class BrainCloudUserItems {
   /// associated itemDef with each user item, with language fields
   ///limited to the current or default language.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - GetUserInventoryPage
   ///
   /// @param context
@@ -137,7 +137,7 @@ class BrainCloudUserItems {
   ///itemDef with each user item, with language fields limited
   ///to the current or default language.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - GetUserInventoryPageOffset
   ///
   /// @param context
@@ -177,7 +177,7 @@ class BrainCloudUserItems {
   /// itemDef with language fields limited to the current
   ///or default language.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
   /// @param itemId
@@ -209,7 +209,7 @@ class BrainCloudUserItems {
 
   /// Gifts item to the specified player.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
   /// @param profileId
@@ -257,7 +257,7 @@ class BrainCloudUserItems {
   ///response includes associated itemDef with language fields
   /// limited to the current or default language.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
   /// @param defId
@@ -299,7 +299,7 @@ class BrainCloudUserItems {
   /// Retrieves and transfers the gift item from the specified player,
   //who must have previously called giveUserItemTo.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - GetUserItem
   ///
   /// @param defId
@@ -340,7 +340,7 @@ class BrainCloudUserItems {
   ///or default language), along with the currency refunded
   ///and currency balances.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - SellUserItem
   ///
   /// @param itemId
@@ -385,7 +385,7 @@ class BrainCloudUserItems {
 
   /// Updates the item data on the specified user item.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - UpdateUserItemData
   ///
   /// @param itemId
@@ -423,7 +423,7 @@ class BrainCloudUserItems {
 
   /// Uses the specified item, potentially consuming it.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - UseUserItem
   ///
   /// @param itemId
@@ -465,7 +465,7 @@ class BrainCloudUserItems {
 
   /// Publishes the specified item to the item management attached blockchain. Results are reported asynchronously via an RTT event.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - PublishUserItemToBlockchain
   ///
   /// @param itemId
@@ -497,7 +497,7 @@ class BrainCloudUserItems {
 
   /// Syncs the caller's user items with the item management attached blockchain. Results are reported asynchronously via an RTT event.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - RefreshBlockchainUserItems
   ///
   /// returns `Future<ServerResponse>`
@@ -522,7 +522,7 @@ class BrainCloudUserItems {
 
   /// removes item from a blockchain.
   ///
-  /// Service Name - UserInventoryManagement
+  /// Service Name - userItems
   /// Service Operation - RemoveUserItemFromBlockchain
   ///
   /// @param itemId
@@ -548,6 +548,188 @@ class BrainCloudUserItems {
     );
     ServerCall sc = ServerCall(ServiceName.userItems,
         ServiceOperation.removeUserItemFromBlockchain, data, callback);
+    _clientRef.sendRequest(sc);
+
+    return completer.future;
+  }
+
+  /// Allows item(s) to be awarded to a user without 
+  /// collecting the purchase amount. If includeDef 
+  /// is true, response includes associated itemDef 
+  /// with language fields limited to the current 
+  /// or default language.
+  ///
+  /// Service Name - userItems
+  /// Service Operation - AwardUserItem
+  ///
+  /// @param defId The unique id of the item definition to award.
+  ///
+  /// @param quantity The quantity of the item to award.
+  ///
+  /// @param includeDef If true, the associated item definition will be included in the response.
+  /// 
+  /// @param optionsJson Optional support for specifying 'blockIfExceedItemMaxStackable' indicating 
+  ///  how to process the award if the defId is for a stackable item with a max 
+  ///  stackable quantity and the specified quantity to award is too high. If 
+  ///  true and the quantity is too high, the call is blocked and an error is returned.
+  ///  If false (default) and quantity is too high, the quantity is adjusted 
+  ///  to the allowed maximum and the quantity not awarded is reported in 
+  ///  response key 'itemsNotAwarded' - unless the adjusted quantity would be 
+  ///  0, in which case the call is blocked and an error is returned.
+  ///
+  Future<ServerResponse> awardUserItemWithOptions(
+      {required String defId,
+      required int quantity,
+      required bool includeDef,
+      required Map<String, Object> optionsJson}) {
+    Completer<ServerResponse> completer = Completer();
+    Map<String, dynamic> data = {};
+    data[OperationParam.userItemsServiceDefId.value] = defId;
+    data[OperationParam.userItemsServiceQuantity.value] = quantity;
+    data[OperationParam.userItemsServiceIncludeDef.value] = includeDef;
+    data[OperationParam.userItemsServiceOptionsJson.value] = optionsJson;
+
+
+    ServerCallback? callback = BrainCloudClient.createServerCallback(
+      (response) => completer.complete(ServerResponse.fromJson(response)),
+      (statusCode, reasonCode, statusMessage) => completer.complete(
+          ServerResponse(
+              statusCode: statusCode,
+              reasonCode: reasonCode,
+              error: statusMessage)),
+    );
+    ServerCall sc = ServerCall(
+        ServiceName.userItems, ServiceOperation.awardUserItem, data, callback);
+    _clientRef.sendRequest(sc);
+
+    return completer.future;
+  }
+
+  /// Purchases a quantity of an item from the specified store,
+  ///if the user has enough funds. If includeDef is true,
+  ///response includes associated itemDef with language fields
+  /// limited to the current or default language.
+  ///
+  /// Service Name - userItems
+  /// Service Operation - PurchaseUserItem
+  ///
+  /// @param defId The unique id of the item definition to purchase.
+  ///
+  /// @param quantity The quantity of the item to purchase.
+  ///
+  /// @param shopId The id identifying the store the item is being purchased from, if applicable.
+  ///
+  /// @param includeDef If true, the associated item definition will be included in the response.
+  ///
+  /// @param optionsJson Optional support for specifying 'blockIfExceedItemMaxStackable' indicating 
+  ///  how to process the award if the defId is for a stackable item with a max 
+  ///  stackable quantity and the specified quantity to award is too high. If 
+  ///  true and the quantity is too high, the call is blocked and an error is returned.
+  ///  If false (default) and quantity is too high, the quantity is adjusted 
+  ///  to the allowed maximum and the quantity not awarded is reported in 
+  ///  response key 'itemsNotAwarded' - unless the adjusted quantity would be 
+  ///  0, in which case the call is blocked and an error is returned.
+  Future<ServerResponse> purchaseUserItemWithOptions(
+      {required String defId,
+      required int quantity,
+      String? shopId,
+      required bool includeDef,
+      required Map<String, Object> optionsJson}) {
+    Completer<ServerResponse> completer = Completer();
+    Map<String, dynamic> data = {};
+    data[OperationParam.userItemsServiceDefId.value] = defId;
+    data[OperationParam.userItemsServiceQuantity.value] = quantity;
+    data[OperationParam.userItemsServiceShopId.value] = shopId;
+    data[OperationParam.userItemsServiceIncludeDef.value] = includeDef;
+
+    ServerCallback? callback = BrainCloudClient.createServerCallback(
+      (response) => completer.complete(ServerResponse.fromJson(response)),
+      (statusCode, reasonCode, statusMessage) => completer.complete(
+          ServerResponse(
+              statusCode: statusCode,
+              reasonCode: reasonCode,
+              error: statusMessage)),
+    );
+    ServerCall sc = ServerCall(ServiceName.userItems,
+        ServiceOperation.purchaseUserItem, data, callback);
+    _clientRef.sendRequest(sc);
+
+    return completer.future;
+  }
+
+  /// Returns list of items on promotion available to the current user.
+  ///
+  /// Service Name - userItems
+  /// Service Operation - GetItemsOnPromotion
+  ///
+  /// @param shopId The id identifying the store the item is being purchased from, if applicable.
+  ///
+  /// @param includeDef If true, the associated item definition will be included in the response.
+  ///
+  /// @param includePromotionDetails If true, the promotion details of the eligible promotions will be included in the response.
+  /// 
+  Future<ServerResponse> getItemsOnPromotion(
+      {required String shopId,
+      required bool includeDef,
+      required bool includePromotionDetails}) {
+    Completer<ServerResponse> completer = Completer();
+    Map<String, dynamic> data = {};
+    data[OperationParam.userItemsServiceShopId.value] = shopId;
+    data[OperationParam.userItemsServiceIncludeDef.value] = includeDef;
+    data[OperationParam.userItemsServiceIncludePromotionDetails.value] = includePromotionDetails;
+
+    ServerCallback? callback = BrainCloudClient.createServerCallback(
+      (response) => completer.complete(ServerResponse.fromJson(response)),
+      (statusCode, reasonCode, statusMessage) => completer.complete(
+          ServerResponse(
+              statusCode: statusCode,
+              reasonCode: reasonCode,
+              error: statusMessage)),
+    );
+    ServerCall sc = ServerCall(ServiceName.userItems,
+        ServiceOperation.getPromotionDetails, data, callback);
+    _clientRef.sendRequest(sc);
+
+    return completer.future;
+  }
+
+  ///
+  /// Returns list of promotional details for the specified item definition, 
+  /// for promotions available to the current user.
+  ///
+  /// Service Name - userItems
+  /// Service Operation - GetItemPromotionalDetails
+  ///
+  /// @param defId The unique id of the item definition to check.
+  ///
+  /// @param shopId The id identifying the store the item is being purchased from, if applicable.
+  ///
+  /// @param includeDef If true, the associated item definition will be included in the response.
+  ///
+  /// @param includePromotionDetails If true, the promotion details of the eligible promotions will be included in the response.
+  /// 
+  Future<ServerResponse> getItemPromotionDetails(
+      {required String defId,
+      required String shopId,
+      required bool includeDef,
+      required bool includePromotionDetails}) {
+    Completer<ServerResponse> completer = Completer();
+    Map<String, dynamic> data = {};
+    data[OperationParam.userItemsServiceDefId.value] = defId;
+    data[OperationParam.userItemsServiceShopId.value] = shopId;
+    data[OperationParam.userItemsServiceIncludeDef.value] = includeDef;
+    data[OperationParam.userItemsServiceIncludePromotionDetails.value] = includePromotionDetails;
+
+    ServerCallback? callback = BrainCloudClient.createServerCallback(
+      (response) => completer.complete(ServerResponse.fromJson(response)),
+      (statusCode, reasonCode, statusMessage) => completer.complete(
+          ServerResponse(
+              statusCode: statusCode,
+              reasonCode: reasonCode,
+              error: statusMessage)),
+    );
+    ServerCall sc = ServerCall(ServiceName.userItems,
+        ServiceOperation.getItemPromotionDetails, data, callback);
     _clientRef.sendRequest(sc);
 
     return completer.future;

--- a/lib/src/internal/operation_param.dart
+++ b/lib/src/internal/operation_param.dart
@@ -770,6 +770,8 @@ class OperationParam {
   static OperationParam userItemsServiceShopId = OperationParam("shopId");
   static OperationParam userItemsServiceNewItemData =
       OperationParam("newItemData");
+  static OperationParam userItemsServiceOptionsJson = OperationParam("optionsJson");
+  static OperationParam userItemsServiceIncludePromotionDetails = OperationParam("includePromotionDetails");
 
   //global app
   static OperationParam globalAppPropertyNames =

--- a/lib/src/internal/service_operation.dart
+++ b/lib/src/internal/service_operation.dart
@@ -813,6 +813,8 @@ class ServiceOperation {
       ServiceOperation._("REFRESH_BLOCKCHAIN_USER_ITEMS");
   static ServiceOperation removeUserItemFromBlockchain =
       ServiceOperation._("REMOVE_USER_ITEM_FROM_BLOCKCHAIN");
+  static ServiceOperation getPromotionDetails = ServiceOperation._("GET_ITEMS_ON_PROMOTION");
+  static ServiceOperation getItemPromotionDetails = ServiceOperation._("GET_ITEM_PROMOTION_DETAILS");
 
   //Group File Services
   static ServiceOperation checkFilenameExists =

--- a/test/user_items_test.dart
+++ b/test/user_items_test.dart
@@ -162,6 +162,40 @@ void main() {
       expect(response.statusCode, StatusCodes.badRequest);
     });
 
+    test("AwardUserItemWithOptions())", () async {
+      Map<String, Object> options = {
+        'blockIfExceedItemMaxStackable': false
+      };
+      ServerResponse response = await bcTest.bcWrapper.userItemsService
+          .awardUserItemWithOptions(defId: "sword001", quantity: 1, includeDef: true, optionsJson: options);
+
+      expect(response.statusCode, StatusCodes.ok);
+    });
+
+    test("PurchaseUserItemWithOptions())", () async {
+      Map<String, Object> options = {
+        'blockIfExceedItemMaxStackable': false
+      };
+      ServerResponse response = await bcTest.bcWrapper.userItemsService
+          .purchaseUserItemWithOptions(defId: "sword001", quantity: 1, includeDef: true, optionsJson: options);
+
+      expect(response.statusCode, StatusCodes.ok);
+    });
+
+    test("GetItemsOnPromotion())", () async {
+      ServerResponse response = await bcTest.bcWrapper.userItemsService
+          .getItemsOnPromotion(shopId: "", includeDef: true, includePromotionDetails: true);
+
+      expect(response.statusCode, StatusCodes.ok);
+    });
+
+    test("GetItemPromotionDetails())", () async {
+      ServerResponse response = await bcTest.bcWrapper.userItemsService
+          .getItemPromotionDetails(defId: "sword001", shopId: "", includeDef: true, includePromotionDetails: true);
+
+      expect(response.statusCode, StatusCodes.ok);
+    });
+
     /// END TEST
     tearDownAll(() {
       bcTest.dispose();


### PR DESCRIPTION
These changes include:
- GetItemPromotionDetails - BCLOUD-12041
- PurchaseUserItemsWithOptions - BCLOUD-12031
- AwardUserItemsWithOptions - BCLOUD-12021
- GetItemsOnPromotion - BCLOUD-12051
- Added missing or corrected documentation in BrainCloudUserItem 